### PR TITLE
Fixing split_by for months and years

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -270,12 +270,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "copernicusmarine"
@@ -611,6 +611,18 @@ test = ["flufl.flake8", "importlib_resources (>=1.3) ; python_version < \"3.9\""
 type = ["pytest-mypy"]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
@@ -938,7 +950,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -1048,6 +1060,22 @@ toolz = "*"
 
 [package.extras]
 complete = ["blosc", "numpy (>=1.20.0)", "pandas (>=1.3)", "pyzmq"]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pyarrow"
@@ -1252,6 +1280,21 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
+    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pystac"
 version = "1.13.0"
 description = "Python library for working with the SpatioTemporal Asset Catalog (STAC) specification"
@@ -1271,6 +1314,28 @@ jinja2 = ["jinja2 (<4.0)"]
 orjson = ["orjson (>=3.5)"]
 urllib3 = ["urllib3 (>=1.26)"]
 validation = ["jsonschema (>=4.18,<5.0)"]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
+    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1615,4 +1680,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "669428da9a3c4c213613acb60f093bb564dea0adec80bb595cd104647b03e0ba"
+content-hash = "695da62efdf9a53ea203fa295ccdee2834360c6fb3b27f36092eab7777e58646"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "copernicusmarine (>=2.1.2,<3.0.0)",
 ]
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.4.1"
+
 [tool.poetry.scripts]
 mdu_downloader = "medunda.downloader:main"
 mdu_reducer = "medunda.reducer:main"

--- a/src/medunda/downloader.py
+++ b/src/medunda/downloader.py
@@ -141,8 +141,8 @@ def download_data (
 
         for start_date, end_date in time_intervals:
 
-            start_str = start.strftime("%Y-%m-%d")
-            end_str = end.strftime("%Y-%m-%d")
+            start_str = start_date.strftime("%Y-%m-%d")
+            end_str = end_date.strftime("%Y-%m-%d")
             file_time = f"{start_str}--{end_str}"
 
             output_filename = f"{domain.name}_{variable}_{frequency}_{file_time}.nc"
@@ -152,7 +152,7 @@ def download_data (
         
             LOGGER.info("Saving file %s", output_filepath)
 
-            LOGGER.info(f"downloading '{frequency}''{variable}' from '{start}' to '{end}'")
+            LOGGER.info(f"downloading '{frequency}''{variable}' from '{start_date}' to '{end_date}'")
 
             LOGGER.info(f"Dataset ID being used: {selected_product}")
             
@@ -209,6 +209,8 @@ def validate_dataset(filepath, variable):
 
 
 def main ():
+    configure_logger(LOGGER)
+
     args=parse_args()       #parse the command line arguments
     
     domain= read_domain (args.domain)
@@ -234,5 +236,4 @@ def main ():
 
 
 if __name__ == "__main__":
-    configure_logger(LOGGER)
     main()

--- a/src/medunda/tools/time_tables.py
+++ b/src/medunda/tools/time_tables.py
@@ -1,14 +1,27 @@
 """
-Tools for dividing a time interval in several subintervals
+Tools for dividing a time interval into several subintervals.
+
+This module provides utility functions to split a time range into intervals
+of months or years, or using a custom interval function. Useful for time-based
+data processing, reporting, or scheduling tasks.
 """
+
+from collections.abc import Callable
 from datetime import datetime
 from datetime import timedelta
+from itertools import pairwise
 
 
-def get_next_month(current_date: datetime):
+def get_next_month(current_date: datetime) -> datetime:
     """
-    Returns a datetime that represents the first date in the month
-    that follows the one that contains `current_date`
+    Returns the first day of the month following the month containing
+    `current_date`.
+
+    Args:
+        current_date: The reference date.
+
+    Returns:
+        The first day of the next month.
     """
     if current_date.month == 12:
         return datetime(year=current_date.year + 1, month=1, day=1)
@@ -17,40 +30,105 @@ def get_next_month(current_date: datetime):
         year=current_date.year, month=current_date.month + 1, day=1
     )
 
-def get_next_year(current_date: datetime):
+
+def get_next_year(current_date: datetime) -> datetime:
     """
-    Like get_next_month, but for the years.
+    Returns the first day of the year following the year containing
+    `current_date`.
+
+    Args:
+        current_date: The reference date.
+
+    Returns:
+        The first day of the next year.
     """
     return datetime(
         year=current_date.year + 1, month=1, day=1
     )
 
 
-def split_by_month(start_date: datetime, end_date:datetime) -> list[tuple[datetime, datetime]]:
+def split_into_intervals(
+        start_date: datetime,
+        end_date: datetime,
+        get_next_point: Callable[[datetime], datetime],
+        resolution: timedelta = timedelta(seconds=1)
+        ) -> list[tuple[datetime, datetime]]:
+    """
+    Splits a time interval into subintervals using a custom function to
+    determine split points.
+
+    Args:
+        start_date: The start of the interval.
+        end_date: The end of the interval.
+        get_next_point: Function that returns the next split point.
+        resolution: The smallest unit of time to subtract from each interval's
+            end (except the last). Defaults to 1 second.
+
+    Returns:
+        List of (start, end) tuples for each subinterval.
+
+    Raises:
+        ValueError: If start_date is after end_date.
+    """
+    if start_date > end_date:
+        raise ValueError("start_date must be before end_date")
+
     current_date = start_date
-    resolution = timedelta(seconds=1)
-    output = []
-    while current_date <= end_date:
-        next_month = get_next_month(current_date)
-        output.append((current_date, next_month - resolution))
-        current_date = next_month
+    split_points = [current_date]
 
-        
-
-
-def split_by_year(start_date: datetime, end_date:datetime) -> list[tuple[datetime, datetime]]:
-    current_date = start_date
-    resolution = timedelta(seconds=1)
-    next_year = min(
-        get_next_year(start_date) - resolution, end_date
-    )
-    intervals = [(current_date, next_year)]
-
-    while intervals[-1][1] < end_date:
-        current_date = get_next_year(intervals[-1][0])
-        next_year = min(
-            get_next_year(start_date) - resolution, end_date
+    while current_date < end_date:
+        current_date = min(
+            get_next_point(current_date), end_date
         )
-        intervals.append((current_date, next_year))
+        split_points.append(current_date)
+    
+    intervals = []
+    for start, end in pairwise(split_points):
+        interval_end = end if end == end_date else end - resolution
+        intervals.append((start, interval_end))
 
     return intervals
+
+
+def split_by_month(
+        start_date: datetime,
+        end_date:datetime
+        ) -> list[tuple[datetime, datetime]]:
+    """
+    Splits a time interval into monthly subintervals.
+
+    Args:
+        start_date: The start of the interval.
+        end_date: The end of the interval.
+
+    Returns:
+        List of (start, end) tuples for each month.
+    """
+    return split_into_intervals(
+        start_date,
+        end_date,
+        get_next_point=get_next_month,
+        resolution=timedelta(seconds=1)
+    )
+
+
+def split_by_year(
+        start_date: datetime,
+        end_date:datetime
+        ) -> list[tuple[datetime, datetime]]:
+    """
+    Splits a time interval into yearly subintervals.
+
+    Args:
+        start_date: The start of the interval.
+        end_date: The end of the interval.
+
+    Returns:
+        List of (start, end) tuples for each year.
+    """
+    return split_into_intervals(
+        start_date,
+        end_date,
+        get_next_point=get_next_year,
+        resolution=timedelta(seconds=1)
+    )

--- a/tests/test_time_tables.py
+++ b/tests/test_time_tables.py
@@ -1,0 +1,72 @@
+import pytest
+from datetime import datetime, timedelta
+from medunda.tools import time_tables
+
+
+def test_get_next_month_normal():
+    date = datetime(2023, 5, 15)
+    result = time_tables.get_next_month(date)
+    assert result == datetime(2023, 6, 1)
+
+
+def test_get_next_month_december():
+    date = datetime(2023, 12, 31)
+    result = time_tables.get_next_month(date)
+    assert result == datetime(2024, 1, 1)
+
+
+def test_get_next_year():
+    date = datetime(2022, 7, 10)
+    result = time_tables.get_next_year(date)
+    assert result == datetime(2023, 1, 1)
+
+
+def test_split_by_month_single_month():
+    start = datetime(2023, 5, 2)
+    end = datetime(2023, 5, 12)
+    intervals = time_tables.split_by_month(start, end)
+    assert len(intervals) == 1
+    assert intervals[0][0] == start
+    assert intervals[0][1] == datetime(2023, 5, 12)
+
+
+def test_split_by_month_multiple_months():
+    start = datetime(2023, 4, 15)
+    end = datetime(2023, 6, 10)
+    intervals = time_tables.split_by_month(start, end)
+    assert len(intervals) == 3
+    assert intervals[0][0] == start
+    assert intervals[1][0] == datetime(2023, 5, 1)
+    assert intervals[2][0] == datetime(2023, 6, 1)
+    assert intervals[2][1] == end
+
+
+def test_split_by_month_between_years():
+    start = datetime(2023, 11, 15)
+    end = datetime(2024, 2, 7)
+    intervals = time_tables.split_by_month(start, end)
+    assert len(intervals) == 4
+    assert intervals[0][0] == start
+    assert intervals[1][0] == datetime(2023, 12, 1)
+    assert intervals[2][0] == datetime(2024, 1, 1)
+    assert intervals[3][0] == datetime(2024, 2, 1)
+    assert intervals[3][1] == end
+
+
+def test_split_by_year_single_year():
+    start = datetime(2022, 2, 12)
+    end = datetime(2022, 11, 29)
+    intervals = time_tables.split_by_year(start, end)
+    assert len(intervals) == 1
+    assert intervals[0][0] == start
+    assert intervals[0][1] == end
+
+
+def test_split_by_year_multiple_years():
+    start = datetime(2021, 6, 1)
+    end = datetime(2023, 2, 1)
+    intervals = time_tables.split_by_year(start, end)
+    assert len(intervals) == 3
+    assert intervals[0][0] == start
+    assert intervals[1][0] == datetime(2022, 1, 1)
+    assert intervals[-1][1] == end


### PR DESCRIPTION
This pull request fixes several bugs in the current implementation of the downloader: specifically, all the ones I was able to identify.

Since the `downloader` can now retrieve data for multiple variables, I had to update the interface of the `download_data` function. Instead of returning a list of all downloaded files, it now returns a dictionary where each key is a variable and the corresponding value is a list of files downloaded for that variable.

This PR also introduces *tests*: a set of small routines that verify whether the code behaves as expected. The tests are run using a dedicated library called `pytest`, which has been added to the `pyproject.toml` file.
