### PR TITLE
Split downloads by year

### DIFF
--- a/src/medunda/downloader.py
+++ b/src/medunda/downloader.py
@@ -100,7 +100,7 @@ def configure_parser(
         type=str,
         required=False,
         choices=["month", "year", "whole"],
-        default="whole",
+        default="year",
         help="Split the downloaded dataset by month, year or download all data together",
     )
 


### PR DESCRIPTION
In order to avoid repeatedly downloading single-file downloads when using the resume function, this PR updates the default setting of the downloader to split the dataset by year ensuring the resume function works correctly.