### PR TITLE
Rename Dataset to GeoDataCollection

### DIFF
--- a/src/medunda/__init__.py
+++ b/src/medunda/__init__.py
@@ -1,4 +1,3 @@
-from medunda.components.dataset import Dataset
-from medunda.components.dataset import read_dataset
+from medunda.components.geodata import GeoDataCollection
 
-__all__ = ["Dataset", "read_dataset"]
+__all__ = ["GeoDataCollection"]

--- a/src/medunda/components/geodata.py
+++ b/src/medunda/components/geodata.py
@@ -22,7 +22,7 @@ from medunda.tools.typing import VarName
 LOGGER = getLogger(__name__)
 
 
-class Dataset(BaseModel):
+class GeoDataCollection(BaseModel):
     """
     A class to represent a dataset for a specific domain.
 
@@ -51,7 +51,7 @@ class Dataset(BaseModel):
             raise ValueError(
                 f'Provider config file "{file_path}" does not exist.'
             )
-        return file_path.resolve() if file_path is not None else file_path
+        return file_path.resolve() if file_path is not None else None
 
     def get_n_of_time_steps(self) -> int:
         """
@@ -272,40 +272,40 @@ class Dataset(BaseModel):
 
         return dataset_data
 
+    @staticmethod
+    def read_from_disk(data_path: PathLike | str) -> "GeoDataCollection":
+        """
+        Reads a GeoDataCollection from the specified path.
 
-def read_dataset(dataset_path: PathLike | str) -> Dataset:
-    """
-    Reads a dataset from the specified path.
+        Args:
+            data_path: The path to the directory that stores the geodata collection.
 
-    Args:
-        dataset_path: The path to the dataset file.
+        Returns:
+            A GeoDataCollection object containing the data from the file.
+        """
+        LOGGER.info('Reading geodata collection from "%s"', data_path)
+        data_path = Path(data_path)
 
-    Returns:
-        A Dataset object containing the data from the file.
-    """
-    LOGGER.info('Reading dataset from "%s"', dataset_path)
-    dataset_path = Path(dataset_path)
+        if not data_path.exists():
+            raise FileNotFoundError(
+                f'Geodata collection file "{data_path}" does not exist.'
+            )
 
-    if not dataset_path.exists():
-        raise FileNotFoundError(
-            f'Dataset file "{dataset_path}" does not exist.'
-        )
+        if data_path.is_dir():
+            LOGGER.debug(
+                'Data path "%s" is a directory, reading medunda file',
+                data_path,
+            )
+            main_dataset_dir = data_path.resolve()
+            data_path = data_path / "medunda_geodata_collection.json"
+        else:
+            main_dataset_dir = data_path.parent.resolve()
 
-    if dataset_path.is_dir():
-        LOGGER.debug(
-            'Dataset path "%s" is a directory, reading medunda file',
-            dataset_path,
-        )
-        main_dataset_dir = dataset_path.resolve()
-        dataset_path = dataset_path / "medunda_dataset.json"
-    else:
-        main_dataset_dir = dataset_path.parent.resolve()
+        dataset_dict = yaml.safe_load(data_path.read_text())
+        dataset = GeoDataCollection.model_validate(dataset_dict)
 
-    dataset_dict = yaml.safe_load(dataset_path.read_text())
-    dataset = Dataset.model_validate(dataset_dict)
+        dataset.main_path = main_dataset_dir
 
-    dataset.main_path = main_dataset_dir
+        LOGGER.debug("Dataset read successfully: %s", dataset)
 
-    LOGGER.debug("Dataset read successfully: %s", dataset)
-
-    return dataset
+        return dataset

--- a/src/medunda/downloader.py
+++ b/src/medunda/downloader.py
@@ -2,7 +2,7 @@
 The downloader is one of the tools that Medunda provides to facilitate the
 downloading of model data from various sources.
 
-Its main job is creating a :class:`medunda.components.dataset.Dataset`, which
+Its main job is creating a :class:`medunda.components.geodata.GeoDataCollection`, which
 is the core data structure used by Medunda to manage and process the data
 produced by one or more model runs.
 
@@ -20,9 +20,8 @@ from sys import exit as sys_exit
 import xarray as xr
 
 from medunda.components.data_files import DataFile
-from medunda.components.dataset import Dataset
-from medunda.components.dataset import read_dataset
 from medunda.components.frequencies import Frequency
+from medunda.components.geodata import GeoDataCollection
 from medunda.components.variables import VariableDataset
 from medunda.domains.domain import ConcreteDomain
 from medunda.domains.domain import read_domain
@@ -208,12 +207,13 @@ def download_data(
     if not output_dir.is_dir():
         raise ValueError(f"Output directory {output_dir} is not a directory")
 
-    # We want to prepare a Dataset object that will contain the path of all the
+    # We want to prepare a GeoDataCollection object that will contain the path
+    # of all the
     # files that we will download.
     downloaded_files: dict[VarName, tuple[DataFile, ...]] = {}
 
     # Dataset file
-    dataset_file = output_dir / "medunda_dataset.json"
+    dataset_file = output_dir / "medunda_geodata_collection.json"
     if dataset_file.exists():
         raise IOError(
             f"Dataset file {dataset_file} already exists. "
@@ -248,9 +248,10 @@ def download_data(
 
         downloaded_files[variable] = tuple(files_for_current_var)
 
-    # Create a Dataset object that will describe the data that we are going
+    # Create a GeoDataCollection object that will describe the data that we
+    # are going
     # to download.
-    dataset = Dataset(
+    dataset = GeoDataCollection(
         domain=domain,
         start_date=start,
         end_date=end,
@@ -265,7 +266,8 @@ def download_data(
     dataset_file.write_text(dataset.model_dump_json(indent=4) + "\n")
 
     # Download the data for each variable. We delegate the actual download
-    # to the Dataset class, which will handle the downloading of the data
+    # to the GeoDataCollection class, which will handle the downloading of the
+    # data
     # files for each variable.
     LOGGER.info("Downloading data...")
     dataset.download_data()
@@ -341,7 +343,7 @@ def downloader(args):
                     )
 
     else:
-        dataset = read_dataset(args.dataset_dir)
+        dataset = GeoDataCollection.read_from_disk(args.dataset_dir)
 
         LOGGER.info("Resuming the download...")
 

--- a/src/medunda/interfaces/bottom_cell_map.py
+++ b/src/medunda/interfaces/bottom_cell_map.py
@@ -14,7 +14,7 @@ from dask.dataframe.dispatch import make_meta
 from dask.delayed import Delayed
 from dask.delayed import delayed
 
-from medunda.components.dataset import Dataset
+from medunda.components.geodata import GeoDataCollection
 from medunda.tools.typing import VarName
 
 LOGGER = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class BottomCellMap:
     grid points and extract the corresponding data.
 
     Args:
-        dataset (Dataset): The dataset containing the model data.
+        dataset (GeoDataCollection): The dataset containing the model data.
         time_range (timedelta): The time range around each point's time to consider for
             data extraction. For each point, data will be extracted starting from the
             point's time minus this range to the point's time.
@@ -155,7 +155,7 @@ class BottomCellMap:
 
     def __init__(
         self,
-        dataset: Dataset,
+        dataset: GeoDataCollection,
         time_range: timedelta,
         lat_column: str = "latitude",
         lon_column: str = "longitude",

--- a/src/medunda/reducer.py
+++ b/src/medunda/reducer.py
@@ -19,7 +19,7 @@ from medunda.actions import extract_layer_extremes
 from medunda.actions import extract_surface
 from medunda.actions import integrate_between_layers
 from medunda.actions import integration
-from medunda.components.dataset import read_dataset
+from medunda.components.geodata import GeoDataCollection
 from medunda.tools.logging_utils import configure_logger
 
 if __name__ == "__main__":
@@ -144,7 +144,7 @@ def reducer(
 
     # Read the dataset file
     LOGGER.info('Reading dataset from "%s"', dataset_path)
-    dataset = read_dataset(dataset_path)
+    dataset = GeoDataCollection.read_from_disk(dataset_path)
 
     domain = dataset.domain
     LOGGER.debug("Domain: %s", domain.name)


### PR DESCRIPTION
Medunda previously used the term Dataset to represent a collection of data within a specific domain. However, this naming can be easily confused with an Xarray Dataset, which may lead to ambiguity for users.

To avoid this confusion, Dataset has been renamed to GeoDataCollection.