### PR TITLE
Implemented a lazy import mechanism

### DIFF
--- a/src/medunda/actions/average_between_layers.py
+++ b/src/medunda/actions/average_between_layers.py
@@ -1,9 +1,8 @@
 import logging
 
-import numpy as np
-import xarray as xr
-
 from medunda.tools.layers import compute_layer_height
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "average_between_layers"
@@ -29,8 +28,8 @@ def configure_parser(subparsers):
 
 
 def average_between_layers(
-    data: xr.Dataset, depth_min, depth_max
-) -> xr.Dataset:
+    data: "xr.Dataset", depth_min, depth_max
+) -> "xr.Dataset":
     """Computes the vertical average of variables between two specified depths.
     Returns a dataset containing the weighted average of this strata.
     """

--- a/src/medunda/actions/calculate_stats.py
+++ b/src/medunda/actions/calculate_stats.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
-import numpy as np
-import xarray as xr
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "calculate_stats"
@@ -97,7 +97,7 @@ class Stats:
         return results
 
 
-def calculate_stats(data: xr.Dataset, operations) -> xr.Dataset:
+def calculate_stats(data: "xr.Dataset", operations) -> "xr.Dataset":
     """Regroups and compute some statistical operations
     according to the user's choice"""
 

--- a/src/medunda/actions/climatology.py
+++ b/src/medunda/actions/climatology.py
@@ -1,8 +1,7 @@
 import logging
 
-import xarray as xr
-
 from medunda.tools.argparse_utils import date_from_str
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "climatology"
@@ -40,7 +39,7 @@ def configure_parser(subparsers):
     )
 
 
-def configure_data_frequency(data=xr.Dataset):
+def configure_data_frequency(data: "xr.Dataset") -> str:
     ds_title = data.attrs.get("title").lower()
     if "monthly" in ds_title:
         ds_frequency = "monthly"
@@ -86,12 +85,12 @@ def weighted_monthly_average(group, days_in_month):
 
 
 def climatology(
-    data: xr.Dataset,
+    data: "xr.Dataset",
     variable: str,
     frequency: str,
     start_date=None,
     end_date=None,
-) -> xr.Dataset:
+) -> "xr.Dataset":
     # check the variable
     if variable not in data.data_vars:
         available_variables = list(data.data_vars.keys())

--- a/src/medunda/actions/compute_average.py
+++ b/src/medunda/actions/compute_average.py
@@ -1,10 +1,9 @@
 import logging
 
-import numpy as np
-import xarray as xr
-from bitsea.commons.mask import Mask
-
+import medunda.tools.lazy_imports.bitsea.mask as bitsea
 from medunda.actions.average_between_layers import average_between_layers
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "compute_average"
@@ -29,7 +28,7 @@ def configure_parser(subparsers):
     )
 
 
-def get_volume(data: xr.Dataset) -> xr.DataArray:
+def get_volume(data: "xr.Dataset") -> "xr.DataArray":
     """Compute the cell volume"""
     data_var = list(data.data_vars)[0]
     if "time" in data[data_var].dims:
@@ -37,7 +36,7 @@ def get_volume(data: xr.Dataset) -> xr.DataArray:
     else:
         reference = data[data_var]
     tmask = np.logical_not(np.isnan(reference))
-    mask = Mask.from_xarray(dataset=xr.Dataset({"tmask": tmask}))
+    mask = bitsea.Mask.from_xarray(dataset=xr.Dataset({"tmask": tmask}))
     area = xr.DataArray(mask.area, dims=("latitude", "longitude"))
     e3t = xr.DataArray(mask.e3t, dims=("depth", "latitude", "longitude"))
     vol_cell = area * e3t
@@ -52,10 +51,11 @@ def get_volume(data: xr.Dataset) -> xr.DataArray:
     )
 
 
-def compute_average(data: xr.Dataset, axis) -> xr.Dataset:
+def compute_average(data: "xr.Dataset", axis) -> "xr.Dataset":
     """Compute the average on a given axis.
     Args:
         data (xr.Dataset): Input dataset with depth as one of the dimensions.
+        axis: The axis over which to compute the average.
     """
     if axis not in VALID_AXIS.keys():
         raise ValueError(

--- a/src/medunda/actions/extract_annual_extremes.py
+++ b/src/medunda/actions/extract_annual_extremes.py
@@ -1,7 +1,7 @@
 import logging
 
-import pandas as pd
-import xarray as xr
+from medunda.tools.lazy_imports import pd
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "extract_annual_extremes"
@@ -15,8 +15,8 @@ def configure_parser(subparsers):
 
 
 def _extract_annual_extremes(
-    data: xr.Dataset, include_depth: bool
-) -> xr.Dataset:
+    data: "xr.Dataset", include_depth: bool
+) -> "xr.Dataset":
     """Extracts the annual extremes (maximum and minimum) from the dataset.
 
     This is an internal function that performs the actual extraction of annual extremes.
@@ -56,7 +56,7 @@ def _extract_annual_extremes(
     return output
 
 
-def extract_annual_extremes(data: xr.Dataset) -> xr.Dataset:
+def extract_annual_extremes(data: "xr.Dataset") -> "xr.Dataset":
     """Extracts the annual extremes of a variable (maximum and minimum) from the dataset.
 
     This action groups the data by year and computes the minimum and maximum values for

--- a/src/medunda/actions/extract_annual_extremes_per_layer.py
+++ b/src/medunda/actions/extract_annual_extremes_per_layer.py
@@ -1,8 +1,7 @@
 import logging
 
-import xarray as xr
-
 from medunda.actions.extract_annual_extremes import _extract_annual_extremes
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "extract_annual_extremes_per_layer"
@@ -15,7 +14,7 @@ def configure_parser(subparsers):
     )
 
 
-def extract_annual_extremes_per_layer(data: xr.Dataset) -> xr.Dataset:
+def extract_annual_extremes_per_layer(data: "xr.Dataset") -> "xr.Dataset":
     """Extracts the annual extremes (maximum and minimum) from the dataset for each layer.
 
     This action is very similar to `extract_annual_extremes`, but it does not include the depth

--- a/src/medunda/actions/extract_bottom.py
+++ b/src/medunda/actions/extract_bottom.py
@@ -1,7 +1,7 @@
 import logging
 
-import numpy as np
-import xarray as xr
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "extract_bottom"
@@ -13,7 +13,7 @@ def configure_parser(subparsers):
     )
 
 
-def extract_bottom(data: xr.Dataset) -> xr.Dataset:
+def extract_bottom(data: "xr.Dataset") -> "xr.Dataset":
     LOGGER.info(f"reading the file: {data}")
 
     variables = {}

--- a/src/medunda/actions/extract_layer.py
+++ b/src/medunda/actions/extract_layer.py
@@ -1,6 +1,6 @@
 import logging
 
-import xarray as xr
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "extract_layer"
@@ -18,7 +18,7 @@ def configure_parser(subparsers):
     )
 
 
-def extract_layer(data: xr.Dataset, depth) -> xr.Dataset:
+def extract_layer(data: "xr.Dataset", depth: float) -> "xr.Dataset":
     """Extracts the layer nearest to the specified depth from the dataset.
     Returns a dataset containing only the layer extracted.
     """

--- a/src/medunda/actions/extract_surface.py
+++ b/src/medunda/actions/extract_surface.py
@@ -1,6 +1,6 @@
 import logging
 
-import xarray as xr
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "extract_surface"
@@ -12,7 +12,7 @@ def configure_parser(subparsers):
     )
 
 
-def extract_surface(data: xr.Dataset) -> xr.Dataset:
+def extract_surface(data: "xr.Dataset") -> "xr.Dataset":
     LOGGER.info(f"reading the file: {data}")
 
     surface_layer = data.isel(depth=0)

--- a/src/medunda/actions/integrate_between_layers.py
+++ b/src/medunda/actions/integrate_between_layers.py
@@ -1,9 +1,8 @@
 import logging
 
-import numpy as np
-import xarray as xr
-
 from medunda.tools.layers import compute_layer_height
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "integrate_between_layers"
@@ -29,8 +28,8 @@ def configure_parser(subparsers):
 
 
 def integrate_between_layers(
-    data: xr.Dataset, depth_min, depth_max
-) -> xr.Dataset:
+    data: "xr.Dataset", depth_min: float, depth_max: float
+) -> "xr.Dataset":
     """Computes the vertical integral of variables between two specified depths.
     Returns a dataset containing the weighted average of this strata.
     """

--- a/src/medunda/actions/integration.py
+++ b/src/medunda/actions/integration.py
@@ -1,8 +1,7 @@
 import logging
 
-import xarray as xr
-
 from medunda.tools.layers import compute_layer_height
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 ACTION_NAME = "compute_integral"
@@ -15,7 +14,7 @@ def configure_parser(subparsers):
     )
 
 
-def compute_integral(data: xr.Dataset) -> xr.Dataset:
+def compute_integral(data: "xr.Dataset") -> "xr.Dataset":
     layer_height = compute_layer_height(data.depth.values)
     lh = xr.DataArray(layer_height, dims=["depth"])
 

--- a/src/medunda/components/geodata.py
+++ b/src/medunda/components/geodata.py
@@ -5,8 +5,6 @@ from logging import getLogger
 from os import PathLike
 from pathlib import Path
 
-import numpy as np
-import xarray as xr
 import yaml
 from pydantic import BaseModel
 from pydantic import Field
@@ -16,6 +14,8 @@ from medunda.components.data_files import DataFile
 from medunda.components.frequencies import Frequency
 from medunda.domains.domain import ConcreteDomain
 from medunda.providers import get_provider
+from medunda.tools.lazy_imports import numpy as np
+from medunda.tools.lazy_imports import xr
 from medunda.tools.time_tables import split_by_month
 from medunda.tools.typing import VarName
 
@@ -95,7 +95,7 @@ class GeoDataCollection(BaseModel):
         """
         return tuple(self.data_files.keys())
 
-    def get_mask(self) -> xr.Dataset:
+    def get_mask(self) -> "xr.Dataset":
         """
         Returns the mask dataset for the domain.
 
@@ -203,7 +203,7 @@ class GeoDataCollection(BaseModel):
         self,
         variables: Iterable[VarName] | None = None,
         chunks: dict | str | None = "auto",
-    ) -> xr.Dataset:
+    ) -> "xr.Dataset":
         """
         Returns an xarray Dataset for the specified variable.
 

--- a/src/medunda/components/variables.py
+++ b/src/medunda/components/variables.py
@@ -3,12 +3,17 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import ClassVar
 
-import cmocean
-from matplotlib.colors import Colormap
-
+import medunda.tools.lazy_imports.cmocean as lazy_cmocean
+import medunda.tools.lazy_imports.colormap as clp
 from medunda.tools.typing import VarName
 
-DEFAULT_COLORMAP = Colormap("viridis")
+
+# The _DEFAULT_COLORMAP is defined as a function so that it is not evaluated
+# at the time of the definition of the variables, but only when it is actually
+# needed. This is important because the colormap module is lazily imported
+# and we want to avoid importing it if it is not necessary.
+def _DEFAULT_COLORMAP():
+    return clp.Colormap("viridis")
 
 
 @dataclass(frozen=True)
@@ -23,8 +28,8 @@ class Variable:
         name: The unique identifier for the variable.
         label: A human-readable label for the variable. If None, the name is
             used.
-        cmap: The colormap specification. Can be a string name, a Colormap
-            object, or None (uses default colormap).
+        cmap: The colormap specification. Can be a string name or None
+            (uses default colormap).
 
     Raises:
         ValueError: If attempting to create a variable with a name that already exists,
@@ -33,11 +38,11 @@ class Variable:
 
     name: VarName
     label: str | None = None
-    cmap: str | Colormap | None = None
+    cmap: str | None = None
 
     _variables: ClassVar[dict[VarName, "Variable"]] = {}
 
-    def get_colormap(self) -> Colormap:
+    def get_colormap(self) -> "clp.Colormap":
         """
         Returns the colormap associated to this variable.
 
@@ -49,10 +54,10 @@ class Variable:
             A colormap associated to the variable
         """
         if self.cmap is None:
-            return DEFAULT_COLORMAP
-        if isinstance(self.cmap, str):
-            return Colormap(self.cmap)
-        return self.cmap
+            return _DEFAULT_COLORMAP()
+        if self.cmap.lower().startswith("cmo:"):
+            return lazy_cmocean.get_cmocean_map(self.cmap[4:])
+        return clp.Colormap(self.cmap)
 
     def get_label(self) -> str:
         """
@@ -106,34 +111,34 @@ class Variable:
 # cmocean colormaps
 # pyright: reportAttributeAccessIssue=false
 
-Variable("thetao", label="Potential Temperature", cmap=cmocean.cm.thermal)
+Variable("thetao", label="Potential Temperature", cmap="cmo:thermal")
 Variable(
     "bottomT",
     label="Sea water potential temperature at sea floor",
-    cmap=cmocean.cm.thermal,
+    cmap="cmo:thermal",
 )
 Variable(
     "thetao_mean",
     label="Mean Sea water potential Temperature",
-    cmap=cmocean.cm.thermal,
+    cmap="cmo:thermal",
 )
 Variable(
     "to",
     label="Observed Sea water potential Temperature",
-    cmap=cmocean.cm.thermal,
+    cmap="cmo:thermal",
 )
 
 Variable("so", label="Practical Salinity", cmap="viridis")
-Variable("o2", label="Dissolved Oxygen", cmap=cmocean.cm.deep)
-Variable("chl", label="Chlorophyll-a", cmap=cmocean.cm.algae)
-Variable("nppv", label="Net Primary Production", cmap=cmocean.cm.matter)
-Variable("uo", label="Zonal Velocity", cmap=cmocean.cm.balance)
-Variable("vo", label="Meridional Velocity", cmap=cmocean.cm.balance)
-Variable("mlotst", label="Mixed Layer Depth", cmap=cmocean.cm.deep)
-Variable("ph", label="pH", cmap=cmocean.cm.balance)
-Variable("no3", label="Nitrate", cmap=cmocean.cm.matter)
-Variable("po4", label="Phosphate", cmap=cmocean.cm.matter)
-Variable("si", label="Silicate", cmap=cmocean.cm.matter)
+Variable("o2", label="Dissolved Oxygen", cmap="cmo:deep")
+Variable("chl", label="Chlorophyll-a", cmap="cmo:algae")
+Variable("nppv", label="Net Primary Production", cmap="cmo:matter")
+Variable("uo", label="Zonal Velocity", cmap="cmo:balance")
+Variable("vo", label="Meridional Velocity", cmap="cmo:balance")
+Variable("mlotst", label="Mixed Layer Depth", cmap="cmo:deep")
+Variable("ph", label="pH", cmap="cmo:balance")
+Variable("no3", label="Nitrate", cmap="cmo:matter")
+Variable("po4", label="Phosphate", cmap="cmo:matter")
+Variable("si", label="Silicate", cmap="cmo:matter")
 Variable("B1c", label="Aerobic and Anaerobic Bacteria carbon", cmap="viridis")
 Variable(
     "B1n", label="Aerobic and Anaerobic Bacteria nitrogen", cmap="viridis"
@@ -141,29 +146,25 @@ Variable(
 Variable(
     "B1p", label="Aerobic and Anaerobic Bacteria phosphorous", cmap="viridis"
 )
-Variable("P1c", label="Diatoms Biomass_carbon", cmap=cmocean.cm.matter)
-Variable("P2c", label="Flagellates Biomass_carbon", cmap=cmocean.cm.matter)
-Variable(
-    "P3c", label="PicoPhytoplankton Biomass_carbon", cmap=cmocean.cm.matter
-)
-Variable(
-    "P4c", label="Large Phytoplankton Biomass_carbon", cmap=cmocean.cm.matter
-)
+Variable("P1c", label="Diatoms Biomass_carbon", cmap="cmo:matter")
+Variable("P2c", label="Flagellates Biomass_carbon", cmap="cmo:matter")
+Variable("P3c", label="PicoPhytoplankton Biomass_carbon", cmap="cmo:matter")
+Variable("P4c", label="Large Phytoplankton Biomass_carbon", cmap="cmo:matter")
 Variable("Z3c", label="Carnivorous Mesozooplankton_carbon", cmap="viridis")
 Variable("Z4c", label="Omnivorous Mesozooplankton_carbon", cmap="viridis")
 Variable("Z5c", label="Microzooplankton_carbon", cmap="viridis")
 Variable("Z6c", label="Heterotrophic Nanoflagellates", cmap="viridis")
 
-Variable("R1c", label="Dissolved Organic Carbon", cmap=cmocean.cm.matter)
+Variable("R1c", label="Dissolved Organic Carbon", cmap="cmo:matter")
 Variable(
-    "R2c", label="Semi-labile Dissolved Organic Carbon", cmap=cmocean.cm.matter
+    "R2c", label="Semi-labile Dissolved Organic Carbon", cmap="cmo:matter"
 )
 Variable(
     "R3c",
     label="Semi-refactory Dissolved Organic Carbon",
-    cmap=cmocean.cm.matter,
+    cmap="cmo:matter",
 )
-Variable("R6c", label="Particulate Organic Carbon", cmap=cmocean.cm.matter)
+Variable("R6c", label="Particulate Organic Carbon", cmap="cmo:matter")
 
 
 class VariableDataset(Collection[Variable]):

--- a/src/medunda/components/variables.py
+++ b/src/medunda/components/variables.py
@@ -12,7 +12,7 @@ from medunda.tools.typing import VarName
 # at the time of the definition of the variables, but only when it is actually
 # needed. This is important because the colormap module is lazily imported
 # and we want to avoid importing it if it is not necessary.
-def _DEFAULT_COLORMAP():
+def _get_default_colormap():
     return clp.Colormap("viridis")
 
 
@@ -54,7 +54,7 @@ class Variable:
             A colormap associated to the variable
         """
         if self.cmap is None:
-            return _DEFAULT_COLORMAP()
+            return _get_default_colormap()
         if self.cmap.lower().startswith("cmo:"):
             return lazy_cmocean.get_cmocean_map(self.cmap[4:])
         return clp.Colormap(self.cmap)

--- a/src/medunda/domains/domain.py
+++ b/src/medunda/domains/domain.py
@@ -8,14 +8,15 @@ from pathlib import Path
 from typing import Literal
 from typing import Union
 
-import geopandas as gpd
-import numpy as np
-import xarray as xr
 import yaml
-from bitsea.basins.basin import Basin
-from bitsea.basins.region import Polygon
 from pydantic import BaseModel
 from pydantic import field_validator
+
+import medunda.tools.lazy_imports.bitsea.basin as bitsea_basin
+import medunda.tools.lazy_imports.bitsea.region as bitsea_region
+from medunda.tools.lazy_imports import geopandas as gpd
+from medunda.tools.lazy_imports import numpy as np
+from medunda.tools.lazy_imports import xr
 
 MAIN_DIR = Path(__file__).absolute().parent.parent.parent.parent
 
@@ -52,14 +53,14 @@ class Domain(BaseModel, ABC):
         return name
 
     @abstractmethod
-    def compute_selection_mask(self, dataset: xr.Dataset):
+    def compute_selection_mask(self, dataset: "xr.Dataset") -> "np.ndarray":
         raise NotImplementedError
 
 
 class RectangularDomain(Domain):
     type: Literal["RectangularDomain"] = "RectangularDomain"
 
-    def compute_selection_mask(self, dataset: xr.Dataset) -> np.ndarray:
+    def compute_selection_mask(self, dataset: "xr.Dataset") -> "np.ndarray":
         latitudes = dataset.latitude.values
         longitudes = dataset.longitude.values
 
@@ -77,11 +78,11 @@ class PolygonalDomain(Domain):
     point_longitudes: list[float]
     type: Literal["PolygonalDomain"] = "PolygonalDomain"
 
-    def compute_selection_mask(self, dataset: xr.Dataset) -> np.ndarray:
+    def compute_selection_mask(self, dataset: "xr.Dataset") -> "np.ndarray":
         latitudes = dataset.latitude.values
         longitudes = dataset.longitude.values
 
-        polygon = Polygon(
+        polygon = bitsea_region.Polygon(
             lat_list=self.point_latitudes, lon_list=self.point_longitudes
         )
 
@@ -260,7 +261,7 @@ def read_domain(domain_description: Path) -> ConcreteDomain:
         wkt_file = _read_path(geometry["file_path"])
         polygon_name = geometry["polygon_name"]
         with open(wkt_file, "r") as f:
-            available_polys = Polygon.read_WKT_file(f)
+            available_polys = bitsea_region.Polygon.read_WKT_file(f)
 
         try:
             poly = available_polys[polygon_name]
@@ -279,7 +280,7 @@ def read_domain(domain_description: Path) -> ConcreteDomain:
         )
     elif geo_type == "basin":
         basin_uuid = geometry["uuid"]
-        basin = Basin.load_from_uuid(basin_uuid)
+        basin = bitsea_basin.Basin.load_from_uuid(basin_uuid)
 
         if not hasattr(basin, "borders"):
             raise NotImplementedError(

--- a/src/medunda/downloader.py
+++ b/src/medunda/downloader.py
@@ -17,8 +17,6 @@ from datetime import datetime
 from pathlib import Path
 from sys import exit as sys_exit
 
-import xarray as xr
-
 from medunda.components.data_files import DataFile
 from medunda.components.frequencies import Frequency
 from medunda.components.geodata import GeoDataCollection
@@ -29,6 +27,7 @@ from medunda.providers import PROVIDERS
 from medunda.providers import get_provider
 from medunda.tools.argparse_utils import date_from_str
 from medunda.tools.file_names import get_output_filename
+from medunda.tools.lazy_imports import xr
 from medunda.tools.logging_utils import configure_logger
 from medunda.tools.time_tables import split_by_month
 from medunda.tools.time_tables import split_by_year

--- a/src/medunda/interfaces/bottom_cell_map.py
+++ b/src/medunda/interfaces/bottom_cell_map.py
@@ -7,7 +7,6 @@ from typing import Sequence
 import dask.dataframe
 import numpy as np
 import pandas as pd
-import xarray as xr
 from bitsea.commons.geodistances import compute_geodesic_distance
 from bitsea.commons.mask import Mask
 from dask.dataframe.dispatch import make_meta
@@ -15,13 +14,14 @@ from dask.delayed import Delayed
 from dask.delayed import delayed
 
 from medunda.components.geodata import GeoDataCollection
+from medunda.tools.lazy_imports import xr
 from medunda.tools.typing import VarName
 
 LOGGER = logging.getLogger(__name__)
 
 
 def _build_callable_wrapper(
-    f: Callable[[xr.Dataset], dict[str, Any]],
+    f: Callable[["xr.Dataset"], dict[str, Any]],
 ) -> Callable[[np.ndarray, dict, dict[str, Any]], Delayed]:
     """
     Builds a delayed wrapper function for the provided function `f`
@@ -174,7 +174,7 @@ class BottomCellMap:
         callable_wrapper: Callable[
             [np.ndarray, dict, dict[VarName, list]], Delayed
         ],
-        point_dataset: xr.Dataset,
+        point_dataset: "xr.Dataset",
     ) -> Delayed:
         """
         Generate a delayed object that applies the callable_wrapper to a point
@@ -226,8 +226,8 @@ class BottomCellMap:
 
     def _split_into_chunks(
         self,
-        lat_indices: xr.DataArray,
-        lon_indices: xr.DataArray,
+        lat_indices: "xr.DataArray",
+        lon_indices: "xr.DataArray",
         lat_chunks: Sequence[int],
         lon_chunks: Sequence[int],
     ) -> tuple[tuple[tuple[slice, slice], np.ndarray], ...]:
@@ -313,7 +313,7 @@ class BottomCellMap:
 
     def map(
         self,
-        func: Callable[[xr.Dataset], dict[str, Any]],
+        func: Callable[["xr.Dataset"], dict[str, Any]],
         point_table: pd.DataFrame,
         func_meta: dict[str, np.typing.DTypeLike] | None = None,
         delayed: bool = False,

--- a/src/medunda/plots/maps.py
+++ b/src/medunda/plots/maps.py
@@ -1,10 +1,9 @@
 import logging
 
-import matplotlib.pyplot as plt
-import pandas as pd
-import xarray as xr
-
 from medunda.tools.argparse_utils import date_from_str
+from medunda.tools.lazy_imports import pd
+from medunda.tools.lazy_imports import pyplot as plt
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 PLOT_NAME = "plotting_maps"
@@ -35,7 +34,7 @@ def configure_parser(subparsers):
     )
 
 
-def plotting_maps(data: xr.DataArray, metadata: dict, time):
+def plotting_maps(data: "xr.DataArray", metadata: dict, time):
     selected_time = pd.to_datetime(time)
 
     data["time"] = pd.to_datetime(data["time"].values)

--- a/src/medunda/plots/timeseries.py
+++ b/src/medunda/plots/timeseries.py
@@ -1,9 +1,8 @@
 import logging
 
-import matplotlib.pyplot as plt
-import xarray as xr
-
 from medunda.tools.argparse_utils import date_from_str
+from medunda.tools.lazy_imports import pyplot as plt
+from medunda.tools.lazy_imports import xr
 
 LOGGER = logging.getLogger(__name__)
 PLOT_NAME = "plotting_timeseries"
@@ -29,7 +28,7 @@ def configure_parser(subparsers):
 
 
 def plotting_timeseries(
-    data: xr.DataArray, metadata: dict, start_time, end_time
+    data: "xr.DataArray", metadata: dict, start_time, end_time
 ):
     start = start_time
     end = end_time

--- a/src/medunda/plotter.py
+++ b/src/medunda/plotter.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 from pathlib import Path
+from types import MappingProxyType
 
 import medunda.tools.lazy_imports.cmocean as lazy_cmocean
 import medunda.tools.lazy_imports.colormap as clp
@@ -12,26 +13,40 @@ from medunda.tools.logging_utils import configure_logger
 
 LOGGER = logging.getLogger(__name__)
 
-VAR_METADATA = {
-    "o2": {"label": "Oxygen", "unit": "µmol/m³", "cmap": "cmo:deep"},
-    "chl": {
-        "label": "Chlorophyll-a",
-        "unit": "mg/m³",
-        "cmap": "cmo:algae",
-    },
-    "nppv": {
-        "label": "Net Primary Production",
-        "unit": "mg C/m²/day",
-        "cmap": "cmo:matter",
-    },
-    "thetao": {"label": "Temperature", "unit": "°C", "cmap": "coolwarm"},
-    "so": {"label": "Salinity", "unit": "PSU", "cmap": "viridis"},
-}
+VAR_METADATA = MappingProxyType(
+    {
+        "o2": MappingProxyType(
+            {"label": "Oxygen", "unit": "µmol/m³", "cmap": "cmo:deep"}
+        ),
+        "chl": MappingProxyType(
+            {
+                "label": "Chlorophyll-a",
+                "unit": "mg/m³",
+                "cmap": "cmo:algae",
+            }
+        ),
+        "nppv": MappingProxyType(
+            {
+                "label": "Net Primary Production",
+                "unit": "mg C/m²/day",
+                "cmap": "cmo:matter",
+            }
+        ),
+        "thetao": MappingProxyType(
+            {"label": "Temperature", "unit": "°C", "cmap": "coolwarm"}
+        ),
+        "so": MappingProxyType(
+            {"label": "Salinity", "unit": "PSU", "cmap": "viridis"}
+        ),
+    }
+)
 
-DEFAULT_VAR = {
-    "unit": "",
-    "cmap": "viridis",
-}
+DEFAULT_VAR = MappingProxyType(
+    {
+        "unit": "",
+        "cmap": "viridis",
+    }
+)
 
 
 PLOTS = [
@@ -90,9 +105,9 @@ def check_variable(ds, var):
         raise ValueError(f"Variable '{var}' not found in dataset")
 
     if var in VAR_METADATA:
-        var_metadata = VAR_METADATA[var]
+        var_metadata = dict(VAR_METADATA[var])
     else:
-        var_metadata = DEFAULT_VAR
+        var_metadata = dict(DEFAULT_VAR)
         var_metadata["label"] = var
 
     return ds[var], var_metadata

--- a/src/medunda/plotter.py
+++ b/src/medunda/plotter.py
@@ -2,28 +2,28 @@ import argparse
 import logging
 from pathlib import Path
 
-import cmocean
-import xarray as xr
-
+import medunda.tools.lazy_imports.cmocean as lazy_cmocean
+import medunda.tools.lazy_imports.colormap as clp
 from medunda.components.variables import VariableDataset
 from medunda.plots import maps
 from medunda.plots import timeseries
+from medunda.tools.lazy_imports import xr
 from medunda.tools.logging_utils import configure_logger
 
 LOGGER = logging.getLogger(__name__)
 
 VAR_METADATA = {
-    "o2": {"label": "Oxygen", "unit": "µmol/m³", "cmap": cmocean.cm.deep},  # pyright: ignore[reportAttributeAccessIssue]
+    "o2": {"label": "Oxygen", "unit": "µmol/m³", "cmap": "cmo:deep"},
     "chl": {
         "label": "Chlorophyll-a",
         "unit": "mg/m³",
-        "cmap": cmocean.cm.algae,
-    },  # pyright: ignore[reportAttributeAccessIssue]
+        "cmap": "cmo:algae",
+    },
     "nppv": {
         "label": "Net Primary Production",
         "unit": "mg C/m²/day",
-        "cmap": cmocean.cm.matter,
-    },  # pyright: ignore[reportAttributeAccessIssue]
+        "cmap": "cmo:matter",
+    },
     "thetao": {"label": "Temperature", "unit": "°C", "cmap": "coolwarm"},
     "so": {"label": "Salinity", "unit": "PSU", "cmap": "viridis"},
 }
@@ -112,6 +112,15 @@ def plotter(filepath: Path, variable: str, mode: str, args):
 
     with xr.open_dataset(filepath) as ds:
         data_var, metadata = check_variable(ds, variable)
+
+        # Ensure that the metadata contains a colormap object if a colormap
+        # name is provided
+        if "cmap" in metadata and isinstance(metadata["cmap"], str):
+            cmap_name = metadata["cmap"]
+            if cmap_name.startswith("cmo:"):
+                metadata["cmap"] = lazy_cmocean.get_cmocean_map(cmap_name[4:])
+            else:
+                metadata["cmap"] = clp.Colormap(cmap_name)
 
         if mode == "plotting_timeseries":
             if "time" not in ds[variable].dims:

--- a/src/medunda/providers/cmems.py
+++ b/src/medunda/providers/cmems.py
@@ -6,13 +6,12 @@ from pathlib import Path
 from typing import Mapping
 from warnings import warn
 
-import copernicusmarine
-
 from medunda.components.data_files import DataFile
 from medunda.components.frequencies import Frequency
 from medunda.components.variables import VariableDataset
 from medunda.domains.domain import Domain
 from medunda.providers.provider import Provider
+from medunda.tools.lazy_imports import copernicusmarine
 from medunda.tools.typing import VarName
 
 LOGGER = logging.getLogger(__name__)

--- a/src/medunda/providers/local_reanalysis.py
+++ b/src/medunda/providers/local_reanalysis.py
@@ -6,17 +6,17 @@ from pathlib import Path
 from typing import Literal
 
 import netCDF4
-import numpy as np
-import xarray as xr
 import yaml
-from bitsea.commons.mask import Mask
 
+import medunda.tools.lazy_imports.bitsea.mask as bitsea
 from medunda.components.data_files import DataFile
 from medunda.components.frequencies import Frequency
 from medunda.components.variables import Variable
 from medunda.components.variables import VariableDataset
 from medunda.domains.domain import Domain
 from medunda.providers.provider import Provider
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 from medunda.tools.typing import VarName
 
 LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ AVE_FILE_MASK = re.compile(
 def allocate_medunda_data_file(
     var_name: VarName,
     var_units: str | None,
-    meshmask: xr.Dataset,
+    meshmask: "xr.Dataset",
     spatial_slices: dict[Literal["depth", "latitude", "longitude"], slice],
     time_steps: np.ndarray,
     f_pointer: netCDF4.Dataset,
@@ -142,13 +142,13 @@ class LocalReanalysis(Provider):
     def available_variables(self, frequency: Frequency) -> VariableDataset:
         return VariableDataset.all_variables()
 
-    def get_meshmask(self, main_path: Path) -> xr.Dataset:
+    def get_meshmask(self, main_path: Path) -> "xr.Dataset":
         meshmask_path = main_path / "meshmask.nc"
 
         if not meshmask_path.exists():
             compression = {"zlib": True, "complevel": 9}
 
-            bitsea_meshmask = Mask.from_file(Path(self._meshmask))
+            bitsea_meshmask = bitsea.Mask.from_file(Path(self._meshmask))
             xr_meshmask = bitsea_meshmask.to_xarray()
             xr_meshmask.to_netcdf(
                 meshmask_path,

--- a/src/medunda/providers/tar_archive.py
+++ b/src/medunda/providers/tar_archive.py
@@ -12,17 +12,17 @@ from pathlib import Path
 from queue import Queue
 
 import netCDF4
-import numpy as np
-import xarray as xr
 import yaml
-from bitsea.commons.mask import Mask
 
+import medunda.tools.lazy_imports.bitsea.mask as bitsea
 from medunda.components.data_files import DataFile
 from medunda.components.frequencies import Frequency
 from medunda.components.variables import Variable
 from medunda.components.variables import VariableDataset
 from medunda.domains.domain import Domain
 from medunda.providers.provider import Provider
+from medunda.tools.lazy_imports import np
+from medunda.tools.lazy_imports import xr
 from medunda.tools.parallelization import get_n_of_processes
 from medunda.tools.temp_dirs import TemporaryDirectory
 from medunda.tools.typing import VarName
@@ -111,7 +111,7 @@ def reader(
 def allocate_medunda_data_file(
     var_name: VarName,
     var_units: str | None,
-    meshmask: xr.Dataset,
+    meshmask: "xr.Dataset",
     spatial_slices,
     time_steps: np.ndarray,
     f_pointer: netCDF4.Dataset,
@@ -205,7 +205,7 @@ def writer(
     file_path: Path,
     var_name: VarName,
     var_units: str | None,
-    meshmask: xr.Dataset,
+    meshmask: "xr.Dataset",
     spatial_slices: dict[str, slice],
     time_steps: np.ndarray,
 ):
@@ -273,7 +273,7 @@ def writer(
     LOGGER.info("File %s has been written", file_path)
 
 
-def execute_writing_task(args: tuple[TASK, dict, xr.Dataset, int]):
+def execute_writing_task(args: tuple[TASK, dict, "xr.Dataset", int]):
     task, spatial_slices, meshmask, n_processors = args
     (
         output_file_path,
@@ -367,13 +367,15 @@ class TarArchiveProvider(Provider):
             return VariableDataset()
         return VariableDataset(self._frequencies[frequency]["variables"])
 
-    def get_meshmask(self, main_path: Path) -> xr.Dataset:
+    def get_meshmask(self, main_path: Path) -> "xr.Dataset":
         meshmask_path = main_path / "meshmask.nc"
 
         if not meshmask_path.exists():
             compression = {"zlib": True, "complevel": 9}
 
-            bitsea_meshmask = Mask.from_file(Path(self._meshmask["path"]))
+            bitsea_meshmask = bitsea.Mask.from_file(
+                Path(self._meshmask["path"])
+            )
             xr_meshmask = bitsea_meshmask.to_xarray()
             xr_meshmask.to_netcdf(
                 meshmask_path,

--- a/src/medunda/reducer.py
+++ b/src/medunda/reducer.py
@@ -3,10 +3,6 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import dask.array as da
-import numpy as np
-import xarray as xr
-
 from medunda.actions import ActionNotFound
 from medunda.actions import average_between_layers
 from medunda.actions import calculate_stats
@@ -20,6 +16,9 @@ from medunda.actions import extract_surface
 from medunda.actions import integrate_between_layers
 from medunda.actions import integration
 from medunda.components.geodata import GeoDataCollection
+from medunda.tools.lazy_imports import dask_array as da
+from medunda.tools.lazy_imports import numpy as np
+from medunda.tools.lazy_imports import xr
 from medunda.tools.logging_utils import configure_logger
 
 if __name__ == "__main__":

--- a/src/medunda/tools/layers.py
+++ b/src/medunda/tools/layers.py
@@ -1,8 +1,9 @@
-import numpy as np
 from numpy.typing import ArrayLike
 
+from medunda.tools.lazy_imports import numpy as np
 
-def compute_layer_height(layer_centers: ArrayLike) -> np.ndarray:
+
+def compute_layer_height(layer_centers: ArrayLike) -> "np.ndarray":
     """Computes layer thicknesses from cell center depths.
 
     Calculates the thickness of each layer in a vertical column based on the

--- a/src/medunda/tools/lazy_imports/__init__.py
+++ b/src/medunda/tools/lazy_imports/__init__.py
@@ -1,0 +1,30 @@
+import medunda.tools.lazy_imports.copernicusmarine as copernicusmarine
+import medunda.tools.lazy_imports.dask_array as dask_array
+import medunda.tools.lazy_imports.geopandas as geopandas
+import medunda.tools.lazy_imports.numpy as numpy
+import medunda.tools.lazy_imports.pandas as pandas
+import medunda.tools.lazy_imports.pyplot as pyplot
+import medunda.tools.lazy_imports.xarray as xarray
+
+xr = xarray
+da = dask_array
+gpd = geopandas
+np = numpy
+pd = pandas
+plt = pyplot
+
+__all__ = [
+    "copernicusmarine",
+    "da",
+    "dask_array",
+    "xarray",
+    "xr",
+    "gpd",
+    "geopandas",
+    "pandas",
+    "pd",
+    "plt",
+    "pyplot",
+    "numpy",
+    "np",
+]

--- a/src/medunda/tools/lazy_imports/bitsea/basin.py
+++ b/src/medunda/tools/lazy_imports/bitsea/basin.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bitsea.basins.basin import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import bitsea.basins.basin
+
+    return getattr(bitsea.basins.basin, name)

--- a/src/medunda/tools/lazy_imports/bitsea/mask.py
+++ b/src/medunda/tools/lazy_imports/bitsea/mask.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bitsea.commons.mask import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import bitsea.commons.mask
+
+    return getattr(bitsea.commons.mask, name)

--- a/src/medunda/tools/lazy_imports/bitsea/region.py
+++ b/src/medunda/tools/lazy_imports/bitsea/region.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bitsea.basins.region import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import bitsea.basins.region
+
+    return getattr(bitsea.basins.region, name)

--- a/src/medunda/tools/lazy_imports/cmocean.py
+++ b/src/medunda/tools/lazy_imports/cmocean.py
@@ -1,0 +1,15 @@
+_CMOCEAN = None
+
+
+def __getattr__(name: str):
+    global _CMOCEAN
+    if _CMOCEAN is None:
+        import cmocean as _CMOCEAN
+    return getattr(_CMOCEAN, name)
+
+
+def get_cmocean_map(name: str):
+    global _CMOCEAN
+    if _CMOCEAN is None:
+        import cmocean as _CMOCEAN
+    return getattr(_CMOCEAN.cm, name)

--- a/src/medunda/tools/lazy_imports/colormap.py
+++ b/src/medunda/tools/lazy_imports/colormap.py
@@ -1,0 +1,12 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap  # noqa: F401
+
+
+def __getattr__(name: str):
+    if name == "Colormap":
+        from matplotlib.colors import Colormap
+
+        return Colormap
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/medunda/tools/lazy_imports/copernicusmarine.py
+++ b/src/medunda/tools/lazy_imports/copernicusmarine.py
@@ -1,0 +1,23 @@
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from copernicusmarine import *  # noqa: F403
+
+
+_COPERNICUSMARINE = None
+
+
+def __getattr__(name: str):
+    global _COPERNICUSMARINE
+
+    if _COPERNICUSMARINE is None:
+        import copernicusmarine
+
+        # Remove all handlers associated with the copernicusmarine logger
+        copernicusmarine_logger = logging.getLogger("copernicusmarine")
+        copernicusmarine_logger.handlers.clear()
+
+        _COPERNICUSMARINE = copernicusmarine
+
+    return getattr(_COPERNICUSMARINE, name)

--- a/src/medunda/tools/lazy_imports/dask_array.py
+++ b/src/medunda/tools/lazy_imports/dask_array.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dask.array import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import dask.array
+
+    return getattr(dask.array, name)

--- a/src/medunda/tools/lazy_imports/geopandas.py
+++ b/src/medunda/tools/lazy_imports/geopandas.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from geopandas import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import geopandas
+
+    return getattr(geopandas, name)

--- a/src/medunda/tools/lazy_imports/numpy.py
+++ b/src/medunda/tools/lazy_imports/numpy.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from numpy import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import numpy
+
+    return getattr(numpy, name)

--- a/src/medunda/tools/lazy_imports/pandas.py
+++ b/src/medunda/tools/lazy_imports/pandas.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pandas import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import pandas
+
+    return getattr(pandas, name)

--- a/src/medunda/tools/lazy_imports/pyplot.py
+++ b/src/medunda/tools/lazy_imports/pyplot.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from matplotlib.pyplot import *  # noqa: F403
+
+
+def __getattr__(name: str):
+    import matplotlib.pyplot as plt
+
+    return getattr(plt, name)

--- a/src/medunda/tools/lazy_imports/xarray.py
+++ b/src/medunda/tools/lazy_imports/xarray.py
@@ -1,0 +1,11 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xarray import DataArray  # noqa: F401
+    from xarray import Dataset  # noqa: F401
+
+
+def __getattr__(name: str):
+    import xarray
+
+    return getattr(xarray, name)

--- a/src/medunda/tools/logging_utils.py
+++ b/src/medunda/tools/logging_utils.py
@@ -13,8 +13,7 @@ def configure_logger(logger: logging.Logger):
 
     # Remove all handlers associated with the copernicusmarine logger
     copernicusmarine_logger = logging.getLogger("copernicusmarine")
-    while copernicusmarine_logger.hasHandlers():
-        copernicusmarine_logger.handlers.pop()
+    copernicusmarine_logger.handlers.clear()
 
     logging.getLogger("botocore").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.ERROR)


### PR DESCRIPTION
Medunda had an issue where importing all modules at startup significantly increased execution time. This was especially inconvenient for users who only wanted to display the help message or who made a mistake in the command line and had to wait for all imports to complete before seeing the error.

This commit mitigates the problem by introducing a lazy import mechanism that loads modules only when they are actually used. For each major library used by Medunda (numpy, matplotlib, cmocean, pandas, xarray, etc.), a lazy-loading wrapper is now available under medunda.tools.lazy_imports. Modules imported from this package defer loading their dependencies until their members are accessed by the code.

This approach requires some care when writing code. For example, even when importing Xarray with:

`from medunda.tools.lazy_imports import xarray as xr`

using xr.Dataset (or similar objects) in type hints can still trigger the import. Simply reading the function definition (and therefore importing the user’s code) may cause the lazy import mechanism to load the dependency, partially defeating the intended laziness. In this case, it is better to use a string to define the type and deferr the evaluation of the type.